### PR TITLE
fix: remove stray hook invocation

### DIFF
--- a/src/hooks/usePagos.ts
+++ b/src/hooks/usePagos.ts
@@ -459,13 +459,3 @@ export function usePagos(): UsePagosReturn {
     recargarPagos
   }
 }
-
-const { 
-  pagos, 
-  loading, 
-  error, 
-  crearPago,
-  eliminarPago,
-  recargarPagos,
-  procesarPagoAutomatico  // ✅ Agregar esta función
-} = usePagos()


### PR DESCRIPTION
## Summary
- remove accidental top-level call to `usePagos` hook

## Testing
- `npm run lint` (fails: various lint errors remain)


------
https://chatgpt.com/codex/tasks/task_e_689cb6d02cd08320b9494c318ceb732f